### PR TITLE
accept terraform version as a build arg

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM ubuntu:18.04
 
-ENV TERRAFORM_VERSION=0.13.4
+ARG TERRAFORM_VERSION
+ENV LC_ALL=C.UTF-8
 
 RUN apt-get update && apt-get install wget zip gpg -y && \
     wget "https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip" && \

--- a/README.md
+++ b/README.md
@@ -13,5 +13,6 @@ Currently, this image is hosted on [Dockerhub](https://hub.docker.com/repository
 ## How to build image
 
 ```bash
-docker build .
+docker build . --build-arg "TERRAFORM_VERSION=0.14.3" -t zipnz/ansible-terraform:0.14.3
+docker build . --build-arg "TERRAFORM_VERSION=0.13.4" -t zipnz/ansible-terraform:0.13.4
 ```


### PR DESCRIPTION
# Description

We should tag this image in relation to the terraform used, as it will often have a large impact on how things are resolved

1) Accept TERRAFORM_VERSION as a build argument
2) tag images like `zipnz/ansible-terraform:0.14.3`